### PR TITLE
#2 implement choosing language functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,9 @@
     "preact-cli": "^2.0.0"
   },
   "dependencies": {
-    "codemirror": "^5.31.0",
+    "react-codemirror": "^1.0.0",
     "dom-to-image": "^2.6.0",
     "highlight.js": "^9.12.0",
-    "parinfer": "^3.11.0",
-    "parinfer-codemirror": "^1.4.2",
     "preact": "^8.2.1",
     "preact-compat": "^3.17.0"
   }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -5,6 +5,30 @@ import ConfigPanel from './configPanel';
 import CodeEditor from './codeEditor';
 import ScreenshotPreview from './screenshotPreview';
 
+const languages = [
+	{ label: '--language--', value: ''},
+	{ label: 'Clojure', value: 'clojure'},
+	{ label: 'CSS', value: 'css'},
+	{ label: 'Elm', value: 'elm'},
+	{ label: 'Erlang', value: 'erlang'},
+	{ label: 'Go', value: 'go'},
+	{ label: 'Haskell', value: 'haskell'},
+	{ label: 'JavaScript', value: 'javascript'},
+	{ label: 'jsx', value: 'jsx'},
+	{ label: 'Markdown', value: 'markdown'},
+	{ label: 'PHP', value: 'php'},
+	{ label: 'Python', value: 'python'},
+	{ label: 'Ruby', value: 'ruby'},
+	{ label: 'Rust', value: 'rust'},
+	{ label: 'SQL', value: 'sql'},
+	{ label: 'Swift', value: 'swift'},
+	{ label: 'HTML/XML', value: 'xml'},
+	{ label: 'Shell', value: 'shell'},
+	{ label: 'Java', value: 'java'},
+	{ label: 'C#', value: 'cs'},
+	{ label: 'C++', value: 'cpp'}
+]
+
 export default class App extends Component {
 
 	constructor(props) {
@@ -13,7 +37,9 @@ export default class App extends Component {
 		this.state = {
 			background: '#1B202D',
 			fontSize: 14,
-			codeText
+			currentLanguage: '',
+			codeText,
+			languages
 		};
 	}
 
@@ -54,17 +80,27 @@ export default class App extends Component {
 		this.setState((state) => ({ ...state, fontSize }));
 	}
 
+	setLanguage = (language) => {
+		this.setState((state) => ({ ...state, currentLanguage: language }));
+	}
+
 	render() {
 		return (
 			<div class="wrap">
 				<h1>😎 Code Cool 😎</h1>
 
-				<CodeEditor value={this.state.codeText} onChange={this.changeCodeSnippet} />
+				<CodeEditor 
+					value={this.state.codeText} 
+					language={this.state.currentLanguage} 
+					onChange={this.changeCodeSnippet} />
 				<ConfigPanel
 					background={this.state.background}
 					fontSize={this.state.fontSize}
 					onChangeBackground={this.setBackground}
 					onChangeFontSize={this.setFontSize}
+					onChangeLanguage={this.setLanguage}
+					languages={this.state.languages}
+					currentLanguage={this.state.currentLanguage}
 				/>
 
 				<ScreenshotPreview
@@ -72,6 +108,9 @@ export default class App extends Component {
 					value={this.state.codeText}
 					background={this.state.background}
 					fontSize={this.state.fontSize}
+					onChangeLanguage={this.setLanguage}
+					languages={this.state.languages}
+					currentLanguage={this.state.currentLanguage}
 				/>
 
 				<div class="bottom">

--- a/src/components/codeEditor/index.js
+++ b/src/components/codeEditor/index.js
@@ -1,21 +1,41 @@
 import { h, Component } from 'preact';
-import codeMirror from 'codemirror';
-import parinfer from 'parinfer';
-import parinferCodeMirror from 'parinfer-codemirror';
+import CodeMirror from 'react-codemirror';
+
+require('codemirror/mode/clojure/clojure');
+require('codemirror/mode/css/css');
+require('codemirror/mode/elm/elm');
+require('codemirror/mode/erlang/erlang');
+require('codemirror/mode/go/go');
+require('codemirror/mode/haskell/haskell');
+require('codemirror/mode/javascript/javascript');
+require('codemirror/mode/jsx/jsx');
+require('codemirror/mode/markdown/markdown');
+require('codemirror/mode/php/php');
+require('codemirror/mode/python/python');
+require('codemirror/mode/ruby/ruby');
+require('codemirror/mode/rust/rust');
+require('codemirror/mode/sql/sql');
+require('codemirror/mode/swift/swift');
+require('codemirror/mode/xml/xml');
+require('codemirror/mode/clike/clike');
+require('codemirror/mode/shell/shell');
 
 export default class CodeEditor extends Component {
 
-	componentDidMount() {
-		const cm = codeMirror(this.codeEditor);
-		parinferCodeMirror.init(cm);
-		cm.setValue(this.props.value);
-
-		cm.on('change', cm => {
-			this.props.onChange(cm.getValue());
-		});
+	codeUpdated = (value) => {
+		this.props.onChange(value);
 	}
 
 	render() {
-		return <div ref={(editor) => { this.codeEditor = editor; }} class="input" />;
+		let language = this.props.language;
+		if (language === 'java' || language === 'cs' || language === 'cpp') {
+			language = 'clike';
+		}
+		const options = {
+			lineNumbers: true,
+			matchBrackets: true,
+			mode: language
+		}
+		return <CodeMirror className="input" value={this.props.value} onChange={this.codeUpdated} options={options} />
 	}
 }

--- a/src/components/configPanel/index.js
+++ b/src/components/configPanel/index.js
@@ -10,16 +10,31 @@ export default class ConfigPanel extends Component {
 		this.props.onChangeFontSize(event.target.value);
 	}
 
+	changeLanguage = (event) => {
+		this.props.onChangeLanguage(event.target.value);
+	}
+
 	render() {
 		return (
 			<div class="config">
+				<div>
+					<label for="config-language">Language:</label>
+					<select id="config-language" value={this.props.currentLanguage} onChange={this.changeLanguage}>
+					{
+						this.props.languages.map(function(language) {
+							return <option key={language.value}
+							value={language.value}>{language.label}</option>;
+						})
+					}
+					</select>
+				</div>
 				<div class="field cfg-bg">
-					<label for="">Background:</label>
-					<input type="color" onChange={this.changeBackground} value={this.props.background} />
+					<label for="config-color">Background:</label>
+					<input id="config-color" type="color" onChange={this.changeBackground} value={this.props.background} />
 				</div>
 				<div class="field cfg-fsize">
-					<label for="">Font Size:</label>
-					<input type="number" onChange={this.changeFontSize} value={this.props.fontSize} />
+					<label for="config-font-size">Font Size:</label>
+					<input id="config-font-size" type="number" onChange={this.changeFontSize} value={this.props.fontSize} />
 				</div>
 			</div>
 		);

--- a/src/components/screenshotPreview/index.js
+++ b/src/components/screenshotPreview/index.js
@@ -1,9 +1,25 @@
 import { h, Component } from "preact";
 import hljs from "highlight.js";
+import { setTimeout } from "timers";
 
 export default class ScreenshotPreview extends Component {
   componentDidMount() {
-    hljs.highlightBlock(this.code);
+    hljs.initHighlightingOnLoad()
+    setTimeout(this.detectLanguage, 500)
+  }
+
+  detectLanguage = () => {
+    const classNameInsideLanguageList = (className) => {
+      return this.props.languages.find(language => {
+        return language.value === className;
+      });
+    }
+
+    this.code.classList.forEach(className => {
+      if (classNameInsideLanguageList(className)) {
+        this.props.onChangeLanguage(className);
+      }
+    });
   }
 
   componentDidUpdate() {
@@ -14,13 +30,14 @@ export default class ScreenshotPreview extends Component {
   render() {
     const backgroundStyle = `background-color: ${this.props.background}`;
     const fontStyle = `font-size: ${this.props.fontSize}px`;
+    const classNames = `display-code ${this.props.currentLanguage}`
     return (
       <pre class="viewport" style={backgroundStyle}>
         <code
           ref={code => {
             this.code = code;
           }}
-          class="clojure display-code"
+          class={classNames}
           style={fontStyle}
         >
           {this.props.value}

--- a/src/template.html
+++ b/src/template.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-	<script async src="bundle.js"></script>
+	<script async src="/bundle.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
I deleted "parinfer" and "parinfer-docemirror" dependencies, because it is lisp specific libs, but now code-cool is going to be language agnostic tool. But I am not sure that this is ok.

There is a huge list of languages, but I added support only for 20. First reason is UX: some languages are rare used and they would only distract users, and also I tried to limit bundle size.

Also I fixed template.html, because in console I saw a lot of exceptions, now it should work fine.